### PR TITLE
IR Capture Alternate and Reset Pin

### DIFF
--- a/games/ninswitch/README.md
+++ b/games/ninswitch/README.md
@@ -145,6 +145,10 @@ Then run the game until the point your detectable object is seen and stop the ga
 You should then revert `SAVE_FRAMES` back to `False` to increase the frame processing
 rate and prevent filling up the SD-card.
 
+Alternatively, you can use the input `capture_frame` while running the game
+through the site (needs to be bound in dashboard). to capture individual
+frames as opposed to persistently capturing frames.
+
 Assuming you have a working ssh connection, these images can be copied from the
 raspi to current directory on your PC with scp:  
 `scp -r <USER>@<RASPI_ADDRESS>:/opt/srtg-python/imgs/ .`
@@ -202,3 +206,18 @@ async def main():
 
 asyncio.run(main())
 ```
+
+## Setting up with Reset Pin
+
+Trinket M0's have been found to be quite tempermental with some controls.
+It is possible to add reset functionality so it can be reset on a button
+press and between every round of your game. Continue using the `game_simple.py`
+if you decide to use the reset pin.
+
+### Hardware Addendum
+
+During the wiring, add a new jumper to the Trinket and Pi:
+   **RST** to **GPIO22**
+
+*NOTE* - Any unused GPIO pin on the pi can be used but will require updating
+the script (Number in the script will be the GPIO number, not pin number).

--- a/games/ninswitch/game_simple.py
+++ b/games/ninswitch/game_simple.py
@@ -1,5 +1,4 @@
 from surrortg import Game
-from surrortg.inputs import Switch
 from games.ninswitch.ns_gamepad_serial import NSGamepadSerial, NSButton, NSDPad
 from games.ninswitch.ns_switch import NSSwitch
 from games.ninswitch.ns_dpad_switch import NSDPadSwitch

--- a/games/ninswitch/game_simple.py
+++ b/games/ninswitch/game_simple.py
@@ -1,8 +1,27 @@
 from surrortg import Game
+from surrortg.inputs import Switch
 from games.ninswitch.ns_gamepad_serial import NSGamepadSerial, NSButton, NSDPad
 from games.ninswitch.ns_switch import NSSwitch
 from games.ninswitch.ns_dpad_switch import NSDPadSwitch
 from games.ninswitch.ns_joystick import NSJoystick
+import asyncio
+import logging
+import pigpio
+
+pigpio.exceptions = False
+pi = pigpio.pi()
+nsg_reset = 22
+ON = 0
+OFF = 1
+
+
+async def reset_trinket():
+    pi.write(nsg_reset, ON)
+    logging.info(f"\t TRINKET_RESET down")
+    await asyncio.sleep(0.5)
+    pi.write(nsg_reset, OFF)
+    logging.info(f"\t... TRINKET_RESET up")
+    await asyncio.sleep(2)
 
 
 class NinSwitchSimpleGame(Game):
@@ -10,6 +29,7 @@ class NinSwitchSimpleGame(Game):
         # init controls
         self.nsg = NSGamepadSerial()
         self.nsg.begin()
+
         self.io.register_inputs(
             {
                 "left_joystick": NSJoystick(
@@ -43,6 +63,9 @@ class NinSwitchSimpleGame(Game):
     here you could do something with
     on_config, on_prepare, on_pre_game, on_countdown, on_start...
     """
+
+    async def on_prepare(self):
+        await reset_trinket()
 
     async def on_finish(self):
         self.io.disable_inputs()


### PR DESCRIPTION
IR Capture Alternate:
Added a new input for game_imagerec.py, capture_screen(). capture_screen() is an alternate to SAVE_FRAMES where the user can determine when to save a frame as opposed to constantly saving frames while the script is running. 

Reset Pin information
Added new script, game_simple_reset.py which has base Reset functionality for the Trinket M0s. Adds an input for forcing a reset and also resets the Trinket during the on_prepare() phase. 