### PR TITLE
NinSwitch - Home button now admin control

### DIFF
--- a/games/ninswitch/game_simple.py
+++ b/games/ninswitch/game_simple.py
@@ -46,7 +46,7 @@ class NinSwitchSimpleGame(Game):
                 "plus": NSSwitch(self.nsg, NSButton.PLUS),
                 "left_stick": NSSwitch(self.nsg, NSButton.LEFT_STICK),
                 "right_stick": NSSwitch(self.nsg, NSButton.RIGHT_STICK),
-                "home": NSSwitch(self.nsg, NSButton.HOME),
+                "home": NSSwitch(self.nsg, NSButton.HOME, admin = True),        # Define the home button as an admin only control
                 "capture": NSSwitch(self.nsg, NSButton.CAPTURE),
             },
         )

--- a/games/ninswitch/game_simple.py
+++ b/games/ninswitch/game_simple.py
@@ -46,7 +46,9 @@ class NinSwitchSimpleGame(Game):
                 "plus": NSSwitch(self.nsg, NSButton.PLUS),
                 "left_stick": NSSwitch(self.nsg, NSButton.LEFT_STICK),
                 "right_stick": NSSwitch(self.nsg, NSButton.RIGHT_STICK),
-                "home": NSSwitch(self.nsg, NSButton.HOME, admin = True),        # Define the home button as an admin only control
+                "home": NSSwitch(
+                    self.nsg, NSButton.HOME, admin=True
+                ),  # Define the home button as an admin only control
                 "capture": NSSwitch(self.nsg, NSButton.CAPTURE),
             },
         )

--- a/games/ninswitch/game_weplay.py
+++ b/games/ninswitch/game_weplay.py
@@ -202,7 +202,7 @@ class NinSwitchWeplayGame(Game):
                 "plus": NSSwitch(self.nsg, NSButton.PLUS),
                 "left_stick": NSSwitch(self.nsg, NSButton.LEFT_STICK),
                 "right_stick": NSSwitch(self.nsg, NSButton.RIGHT_STICK),
-                "home": NSSwitch(self.nsg, NSButton.HOME),
+                "home": NSSwitch(self.nsg, NSButton.HOME, admin = True),        # Define the home button as an admin only control
                 "capture": NSSwitch(self.nsg, NSButton.CAPTURE),
             },
         )

--- a/games/ninswitch/game_weplay.py
+++ b/games/ninswitch/game_weplay.py
@@ -202,7 +202,9 @@ class NinSwitchWeplayGame(Game):
                 "plus": NSSwitch(self.nsg, NSButton.PLUS),
                 "left_stick": NSSwitch(self.nsg, NSButton.LEFT_STICK),
                 "right_stick": NSSwitch(self.nsg, NSButton.RIGHT_STICK),
-                "home": NSSwitch(self.nsg, NSButton.HOME, admin = True),        # Define the home button as an admin only control
+                "home": NSSwitch(
+                    self.nsg, NSButton.HOME, admin=True
+                ),  # Define the home button as an admin only control
                 "capture": NSSwitch(self.nsg, NSButton.CAPTURE),
             },
         )


### PR DESCRIPTION
Users are putting their switches on the website using either the 'simple' or 'weplay' templates, not realising the damage that can be done by having the home button mapped.

This small change prevents this from happening by changing it to an admin control.
A note could then be built add to the docs/image to explain this and that they should take control via the dashboard if they need to use the home button.